### PR TITLE
ci: Relax push-actor-action pin to @v1

### DIFF
--- a/.github/workflows/push_to_apify.yaml
+++ b/.github/workflows/push_to_apify.yaml
@@ -17,6 +17,6 @@ jobs:
           node-version: 24
 
       - name: Push to Apify
-        uses: apify/push-actor-action@v1.1.1
+        uses: apify/push-actor-action@v1
         with:
           token: ${{ secrets.APIFY_TOKEN }}


### PR DESCRIPTION
## What

Relax the `apify/push-actor-action` pin from `@v1.1.1` to the floating `@v1` tag so this workflow automatically receives patch/minor fixes.

## Why

`push-actor-action@v1.1.1` (and the current `v1`) contains a race condition: it reads `.status` from `apify push --json` and fails the job unless the status is `SUCCEEDED`. When `apify push` returns while the build is still `RUNNING`, the action exits 1 even though the build later succeeds. This has caused spurious "Push to Apify" CI failures.

The fix lives in apify/push-actor-action#22 (`fix: Add explicit wait to apify push`), which passes `--wait-for-finish` so the build is terminal before the status is checked. Once that PR is merged and released, the `v1` floating tag moves to the fix — but a pin to the exact `v1.1.1` patch would never pick it up. Relaxing to `@v1` ensures we follow future fixes.
